### PR TITLE
docs: fix url info

### DIFF
--- a/docs/installation/OpenDID_APIGatewayServer_InstallationAndOperation_Guide.md
+++ b/docs/installation/OpenDID_APIGatewayServer_InstallationAndOperation_Guide.md
@@ -516,4 +516,5 @@ For example, add an application.yml file to `${your-config-dir}` and write the n
 The `application.yml` file located in `${your-config-dir}` will take precedence over the default configuration files.
 - For detailed configuration instructions, please refer to [5. Configuration Guide.](#5-configuration-guide)
 
-[Open DID Installation Guide]: https://github.com/OmniOneID/did-release/blob/develop/unrelease-V1.0.1.0/OepnDID_Installation_Guide-V1.0.1.0.md
+[Open DID Installation Guide]: https://github.com/OmniOneID/did-release/blob/main/release-V2.0.0.0/OpenDID_Installation_Guide-V2.0.0.0.md
+[DID Besu Contract]: https://github.com/OmniOneID/did-besu-contract

--- a/docs/installation/OpenDID_APIGatewayServer_InstallationAndOperation_Guide_ko.md
+++ b/docs/installation/OpenDID_APIGatewayServer_InstallationAndOperation_Guide_ko.md
@@ -508,5 +508,5 @@ docker-compose up -d
   - `${your-config-dir}`에 위치한 `application.yml` 파일은 기본 설정 파일보다 우선적으로 적용됩니다.
 - 자세한 설정은 [5. 설정 가이드](#5-설정-가이드)를 참고합니다.
  
-[Open DID Installation Guide]: https://github.com/OmniOneID/did-release/blob/develop/release-V2.0.0.0/OpenDID_Installation_Guide-V2.0.0.0_ko.md
+[Open DID Installation Guide]: https://github.com/OmniOneID/did-release/blob/main/release-V2.0.0.0/OpenDID_Installation_Guide-V2.0.0.0_ko.md
 [DID Besu Contract]: https://github.com/OmniOneID/did-besu-contract


### PR DESCRIPTION
## Description
Fixed incorrect URL in the Installation documentation section.

## Changes
- Corrected broken/incorrect URL in Installation documentation
- Updated URL to point to the proper resource/endpoint
- Verified that the new URL is accessible and provides the intended content
